### PR TITLE
Update helmrelease.yaml

### DIFF
--- a/clusters/home-cluster/mosquitto/helmrelease.yaml
+++ b/clusters/home-cluster/mosquitto/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: mosquitto
-      version: "2.2.0"
+      version: 2.2.0
       sourceRef:
         kind: HelmRepository
         name: k8s-at-home


### PR DESCRIPTION
Removes quotes around version number. Renovate seems to be complaining about them - I thought this was invalid YAML, so we'll see.