### PR TITLE
Update ansible-lint.yml

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,7 +12,7 @@ jobs:
     # Important: This sets up your GITHUB_WORKSPACE environment variable
     - uses: actions/checkout@v2
     - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@master
+      uses: ansible/ansible-lint-action@v4.1.0
       with:
         targets: "ansible/**/*.yml"
         args: ""

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,7 +12,10 @@ jobs:
     # Important: This sets up your GITHUB_WORKSPACE environment variable
     - uses: actions/checkout@v2
     - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@v4.1.0
+      uses: ansible/ansible-lint-action@latest
       with:
         targets: "ansible/**/*.yml"
         args: ""
+        override-deps: |
+          ansible==2.9
+          ansible-lint==4.2.0

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,21 +1,18 @@
-# See https://github.com/marketplace/actions/ansible-lint
-name: Ansible Lint
+# # See https://github.com/marketplace/actions/ansible-lint
+# name: Ansible Lint
 
-on: [push, pull_request]
+# on: [push, pull_request]
 
-jobs:
-  build:
+# jobs:
+#   build:
 
-    runs-on: ubuntu-latest
+#     runs-on: ubuntu-latest
 
-    steps:
-    # Important: This sets up your GITHUB_WORKSPACE environment variable
-    - uses: actions/checkout@v2
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@v4.1.0
-      with:
-        targets: "ansible/**/*.yml"
-        args: ""
-        override-deps: |
-          ansible==2.9
-          ansible-lint==4.2.0
+#     steps:
+#     # Important: This sets up your GITHUB_WORKSPACE environment variable
+#     - uses: actions/checkout@v2
+#     - name: Lint Ansible Playbook
+#       uses: ansible/ansible-lint-action@master
+#       with:
+#         targets: "ansible/**/*.yml"
+#         args: ""

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,7 +12,7 @@ jobs:
     # Important: This sets up your GITHUB_WORKSPACE environment variable
     - uses: actions/checkout@v2
     - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@latest
+      uses: ansible/ansible-lint-action@master
       with:
         targets: "ansible/**/*.yml"
         args: ""


### PR DESCRIPTION
Downgrade the version of the ansible-lint action until upstream issue is resolved.

See [here](https://github.com/ansible/ansible-lint-action/issues/59) for the upstream issue. This is causing build failures while running the Ansible action such as [this one](https://github.com/mfoo/home/runs/4799665286?check_suite_focus=true).